### PR TITLE
Remove deprecation warning of Config and use RbConfig.

### DIFF
--- a/lib/unix/sys/uptime.rb
+++ b/lib/unix/sys/uptime.rb
@@ -93,7 +93,7 @@ module Sys
     #    Sys::Uptime.boot_time # => Mon Jul 13 06:08:25 -0600 2009
     #
     def self.boot_time
-      if Config::CONFIG['host_os'] =~ /linux/i
+      if RbConfig::CONFIG['host_os'] =~ /linux/i
         Time.now - self.seconds
       elsif respond_to?(:sysctl, true)
         tv = Timeval.new
@@ -128,7 +128,7 @@ module Sys
     #    Sys::Uptime.seconds => 118800
     #
     def self.seconds
-      if Config::CONFIG['host_os'] =~ /linux/i
+      if RbConfig::CONFIG['host_os'] =~ /linux/i
         begin
           IO.read('/proc/uptime').split.first.to_i
         rescue Exception => err


### PR DESCRIPTION
Removed the obsolete and deprecated Config and replaced it with RbConfig.
No more deprecation warnings when running uptime.

Cheers,
